### PR TITLE
Added HTTP Basic Auth to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,13 @@ Now you can use the web API endpoints which return JSON payloads:
   }
 ```
 
+### Authentication
+The API can be secured with a simple username and password through
+[HTTP Basic Authentication][BASICAUTH]. To require authentication
+for all API requests, set the `BUSYLIGHT_API_USER` and
+`BUSYLIGHT_API_PASS` environmental variables before running
+`busylight serve`.
+
 ## Code Examples
 
 Adding light support to your own python applications is easy!
@@ -200,6 +207,7 @@ manager.lights_off(ALL_LIGHTS)
 [WEBAPI]: https://github.com/JnyJny/busylight/blob/master/docs/busylight_api.pdf
 [DEMO]: https://github.com/JnyJny/busylight/raw/master/demo/demo.gif
 
+[BASICAUTH]: https://en.wikipedia.org/wiki/Basic_access_authentication
 [UDEV]: https://en.wikipedia.org/wiki/Udev
 
 [todbot]: https://github.com/todbot

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ for all API requests, set the `BUSYLIGHT_API_USER` and
 `BUSYLIGHT_API_PASS` environmental variables before running
 `busylight serve`.
 
+> :warning: **SECURITY WARNING**: HTTP Basic Auth sends usernames and passwords in *cleartext* (i.e., unencrypted). Use of SSL is highly recommended!
+
 ## Code Examples
 
 Adding light support to your own python applications is easy!


### PR DESCRIPTION
I was interested in running BusyLight's web API on a public-facing server when I noticed that no authentication mechanisms were supported out of the box. This PR adds such functionality using the HTTP Basic Authentication (i.e., username and password) security scheme that's [built-into FastAPI](https://fastapi.tiangolo.com/advanced/security/http-basic-auth/).

Example (with `curl` output paraphrased for clarity) :
```bash
# Start auth-enabled API server
BUSYLIGHT_API_USER=johndoe
BUSYLIGHT_API_PASS=secret
busylight serve &
AUTH_PID=$!

# Try to access API without authenticating
curl -s http://localhost:8888/lights/status
# Response Code: 401 Unauthorized
# Response Body: {"detail": "Not authenticated"}

# Now try with authentication
curl -u johndoe:secret -s http://localhost:8888/lights/status
# Response Code: 200 OK
# Response Body:
#[
#  {
#    "light_id": 0,
#    "name": "LUXAFOR FLAG",
#    "info": {
#      "path": "[redacted]",
#      ...
#      "interface_number": 0
#    },
#    "is_on": true,
#    "color": "#ffa500"
#  }
#]

# API server still works fine without auth
kill $AUTH_PID
unset BUSYLIGHT_API_USER
unset BUSYLIGHT_API_PASS
busylight serve &
curl -s http://localhost:8888/lights/status
# Response Code: 200 OK
# Response Body:
#[
#  {
#    "light_id": 0,
#    "name": "LUXAFOR FLAG",
#    ...
```