### PR TITLE
Add new product id for busylight UC omega

### DIFF
--- a/busylight/lights/kuando/busylight.py
+++ b/busylight/lights/kuando/busylight.py
@@ -18,6 +18,7 @@ class Busylight(USBLight):
         0xF848,  # UC Busylight Alpha
         0x3BCA,  # UC Busylight Alpha
         0x3BCD,  # UC Busylight Omega
+        0x3BCF,  # UC Busylight Omega
     ]
     vendor = "Kuando"
 


### PR DESCRIPTION
Currently, this one is missing.

For more information, see issue #113 .