### PR TITLE
Add additional definition for Blynclight

### DIFF
--- a/busylight/lights/embrava/blynclight.py
+++ b/busylight/lights/embrava/blynclight.py
@@ -18,6 +18,7 @@ class Blynclight(USBLight):
         (0x2C0D, 0x000C): "Blynclight",
         (0x2C0D, 0x0010): "Blynclight Plus",
         (0x0E53, 0x2517): "Blynclight Mini",
+        (0x0E53, 0x2516): "Blynclight"
     }
     vendor = "Embrava"
 


### PR DESCRIPTION
I stumbled across a Blynclight at a local thrift store. When I got home I found your library, but discovered that the Blynclight that I found had different VID and PID than any you have defined in the library. 
I have not tested all of the features, but from some quick tests it seems to work. 