### PR TITLE
busyserve: add CORS middleware

### DIFF
--- a/busylight/__main__.py
+++ b/busylight/__main__.py
@@ -3,6 +3,7 @@
 """
 
 from dataclasses import dataclass, field
+from os import environ
 from typing import List, Optional
 
 import typer
@@ -373,6 +374,8 @@ def serve_http_api(
     ),
 ) -> None:
     """Serve a HTTP API to access available lights."""
+
+    environ["BUSYLIGHT_DEBUG"] = str(debug)
 
     (logger.enable if debug else logger.disable)("busylight")
     logger.info("serving http api")

--- a/busylight/api/busylight_api.py
+++ b/busylight/api/busylight_api.py
@@ -85,8 +85,9 @@ class BusylightAPI(FastAPI):
         logger.info(
             "Set up CORS Access-Control-Allow-Origin header, if environment variable is set.")
         try:
-            self.origins = json_loads(environ["BUSYLIGHT_API_CORS_ORIGINS_LIST"])
-            logger.info("CORS list: {}".format(self.origins))
+            self.origins = json_loads(
+                environ["BUSYLIGHT_API_CORS_ORIGINS_LIST"])
+            logger.info("CORS Access-Control-Allow-Origin list: {}".format(self.origins))
             logger.info("Found CORS allowed origins in environment.")
         except KeyError:
             logger.info("Did NOT find CORS allowed origins in environment.")

--- a/busylight/api/busylight_api.py
+++ b/busylight/api/busylight_api.py
@@ -6,6 +6,7 @@ from multiprocessing import context
 from os import environ
 from secrets import compare_digest
 from typing import Callable, List, Dict, Any
+from weakref import KeyedRef
 
 from fastapi import Depends, FastAPI, HTTPException, Path, Request, status
 from fastapi.middleware.cors import CORSMiddleware
@@ -64,10 +65,14 @@ busylightapi_security = HTTPBasic()
 class BusylightAPI(FastAPI):
     def __init__(self):
 
-        global_options = GlobalOptions(
-            debug=environ["BUSYLIGHT_DEBUG"]
-        )
-        logger.info('Debug: {}'.format(global_options.debug))
+        try:
+            global_options = GlobalOptions(
+                debug=environ["BUSYLIGHT_DEBUG"]
+            )
+            logger.info("Found debug flag in environment.")
+            logger.info("Debug: {}".format(global_options.debug))
+        except KeyError:
+            logger.info("Did NOT find debug flag in environment.")
 
         dependencies = []
         logger.info("Set up authentication, if environment variables set.")
@@ -91,6 +96,9 @@ class BusylightAPI(FastAPI):
             logger.info("Found CORS allowed origins in environment.")
         except KeyError:
             logger.info("Did NOT find CORS allowed origins in environment.")
+
+            if global_options.debug == True:
+                logger.info("However, debug mode is enabled! Using debug mode CORS allowed origins: \'[\"http://localhost\", \"http://127.0.0.1\"]\'")
             logger.info(
                 "CORS Access-Control-Allow-Origin header will NOT be set.")
             self.origins = None

--- a/busylight/api/busylight_api.py
+++ b/busylight/api/busylight_api.py
@@ -67,7 +67,7 @@ class BusylightAPI(FastAPI):
         global_options = GlobalOptions(
             debug=environ["BUSYLIGHT_DEBUG"]
         )
-        logger.info('GlobalOptions.debug: {}'.format(global_options.debug))
+        logger.info('Debug: {}'.format(global_options.debug))
 
         dependencies = []
         logger.info("Set up authentication, if environment variables set.")
@@ -85,8 +85,7 @@ class BusylightAPI(FastAPI):
         logger.info(
             "Set up CORS Access-Control-Allow-Origin header, if environment variable is set.")
         try:
-            self.origins = json_loads(
-                environ["BUSYLIGHT_API_CORS_ORIGINS_LIST"])
+            self.origins = json_loads(environ["BUSYLIGHT_API_CORS_ORIGINS_LIST"])
             logger.info("Found CORS allowed origins in environment.")
         except KeyError:
             logger.info("Did NOT find CORS allowed origins in environment.")

--- a/busylight/api/busylight_api.py
+++ b/busylight/api/busylight_api.py
@@ -13,6 +13,7 @@ from json import loads as json_loads
 from loguru import logger
 
 from .. import __version__
+from ..__main__ import GlobalOptions
 
 from ..color import ColorTuple, parse_color_string, colortuple_to_name, ColorLookupError
 from ..effects import Effects
@@ -61,10 +62,11 @@ busylightapi_security = HTTPBasic()
 class BusylightAPI(FastAPI):
     def __init__(self):
 
+        logger.info('GlobalOptions.debug: {}'.format(GlobalOptions.debug))
+
         dependencies = []
         logger.info("Set up authentication, if environment variables set.")
         try:
-
             self.username = environ["BUSYLIGHT_API_USER"]
             self.password = environ["BUSYLIGHT_API_PASS"]
             dependencies.append(Depends(self.authenticate_user))

--- a/busylight/api/busylight_api.py
+++ b/busylight/api/busylight_api.py
@@ -84,6 +84,8 @@ class BusylightAPI(FastAPI):
 
         logger.info(
             "Set up CORS Access-Control-Allow-Origin header, if environment variable is set.")
+        self.origins = json_loads(environ["BUSYLIGHT_API_CORS_ORIGINS_LIST"])
+        logger.info("CORS list: {}".format(self.origins))
         try:
             self.origins = json_loads(environ["BUSYLIGHT_API_CORS_ORIGINS_LIST"])
             logger.info("CORS list: {}".format(self.origins))

--- a/busylight/api/busylight_api.py
+++ b/busylight/api/busylight_api.py
@@ -84,8 +84,6 @@ class BusylightAPI(FastAPI):
 
         logger.info(
             "Set up CORS Access-Control-Allow-Origin header, if environment variable is set.")
-        logger.info(environ["BUSYLIGHT_API_CORS_ORIGINS_LIST"])
-        logger.info("CORS list: {}".format(self.origins))
         try:
             self.origins = json_loads(environ["BUSYLIGHT_API_CORS_ORIGINS_LIST"])
             logger.info("CORS list: {}".format(self.origins))

--- a/busylight/api/busylight_api.py
+++ b/busylight/api/busylight_api.py
@@ -84,7 +84,7 @@ class BusylightAPI(FastAPI):
 
         logger.info(
             "Set up CORS Access-Control-Allow-Origin header, if environment variable is set.")
-        self.origins = json_loads(environ["BUSYLIGHT_API_CORS_ORIGINS_LIST"])
+        logger.info(environ["BUSYLIGHT_API_CORS_ORIGINS_LIST"])
         logger.info("CORS list: {}".format(self.origins))
         try:
             self.origins = json_loads(environ["BUSYLIGHT_API_CORS_ORIGINS_LIST"])

--- a/busylight/api/busylight_api.py
+++ b/busylight/api/busylight_api.py
@@ -82,7 +82,7 @@ class BusylightAPI(FastAPI):
             self.password = None
 
         # Get and save the CORS Access-Control-Allow-Origin header
-        logger.info("Set up CORS Access-Control-Allow-Origin header, if environment variable is set.")
+        logger.info("Set up CORS Access-Control-Allow-Origin header, if environment variable BUSYLIGHT_API_CORS_ORIGINS_LIST is set.")
         self.origins = json_loads(environ.get("BUSYLIGHT_API_CORS_ORIGINS_LIST", None))
 
         # Validate that BUSYLIGHT_API_CORS_ORIGINS_LIST is a list of strings

--- a/busylight/api/busylight_api.py
+++ b/busylight/api/busylight_api.py
@@ -83,7 +83,7 @@ class BusylightAPI(FastAPI):
 
         # Get and save the CORS Access-Control-Allow-Origin header
         logger.info("Set up CORS Access-Control-Allow-Origin header, if environment variable BUSYLIGHT_API_CORS_ORIGINS_LIST is set.")
-        self.origins = json_loads(environ.get("BUSYLIGHT_API_CORS_ORIGINS_LIST", None))
+        self.origins = json_loads(environ.get("BUSYLIGHT_API_CORS_ORIGINS_LIST", []))
 
         # Validate that BUSYLIGHT_API_CORS_ORIGINS_LIST is a list of strings
         if (not isinstance(self.origins, list)) or any(not isinstance(item, str) for item in self.origins):

--- a/busylight/api/busylight_api.py
+++ b/busylight/api/busylight_api.py
@@ -1,12 +1,9 @@
 """BusyLight API
 """
 
-from contextvars import Context
-from multiprocessing import context
 from os import environ
 from secrets import compare_digest
 from typing import Callable, List, Dict, Any
-from weakref import KeyedRef
 
 from fastapi import Depends, FastAPI, HTTPException, Path, Request, status
 from fastapi.middleware.cors import CORSMiddleware
@@ -92,13 +89,15 @@ class BusylightAPI(FastAPI):
         try:
             self.origins = json_loads(
                 environ["BUSYLIGHT_API_CORS_ORIGINS_LIST"])
-            logger.info("CORS Access-Control-Allow-Origin list: {}".format(self.origins))
+            logger.info(
+                "CORS Access-Control-Allow-Origin list: {}".format(self.origins))
             logger.info("Found CORS allowed origins in environment.")
         except KeyError:
             logger.info("Did NOT find CORS allowed origins in environment.")
 
             if global_options.debug == True:
-                logger.info("However, debug mode is enabled! Using debug mode CORS allowed origins: \'[\"http://localhost\", \"http://127.0.0.1\"]\'")
+                logger.info(
+                    "However, debug mode is enabled! Using debug mode CORS allowed origins: \'[\"http://localhost\", \"http://127.0.0.1\"]\'")
             logger.info(
                 "CORS Access-Control-Allow-Origin header will NOT be set.")
             self.origins = None
@@ -543,7 +542,8 @@ async def flash_light_impressively(
     rgb_b = parse_color_string(color_b, dim)
 
     fli = Effects.for_name("blink")(
-        rgb_a, speed.duty_cycle / 10, off_color=rgb_b)
+        rgb_a, speed.duty_cycle / 10, off_color=rgb_b
+    )
 
     await busylightapi.apply_effect(fli, light_id)
 
@@ -573,7 +573,8 @@ async def flash_lights_impressively(
     rgb_b = parse_color_string(color_b, dim)
 
     fli = Effects.for_name("blink")(
-        rgb_a, speed.duty_cycle / 10, off_color=rgb_b)
+        rgb_a, speed.duty_cycle / 10, off_color=rgb_b
+    )
 
     await busylightapi.apply_effect(fli)
 

--- a/busylight/api/busylight_api.py
+++ b/busylight/api/busylight_api.py
@@ -83,7 +83,7 @@ class BusylightAPI(FastAPI):
 
         # Get and save the CORS Access-Control-Allow-Origin header
         logger.info("Set up CORS Access-Control-Allow-Origin header, if environment variable BUSYLIGHT_API_CORS_ORIGINS_LIST is set.")
-        self.origins = json_loads(environ.get("BUSYLIGHT_API_CORS_ORIGINS_LIST", []))
+        self.origins = json_loads(environ.get("BUSYLIGHT_API_CORS_ORIGINS_LIST", "[]"))
 
         # Validate that BUSYLIGHT_API_CORS_ORIGINS_LIST is a list of strings
         if (not isinstance(self.origins, list)) or any(not isinstance(item, str) for item in self.origins):

--- a/busylight/api/busylight_api.py
+++ b/busylight/api/busylight_api.py
@@ -86,6 +86,7 @@ class BusylightAPI(FastAPI):
             "Set up CORS Access-Control-Allow-Origin header, if environment variable is set.")
         try:
             self.origins = json_loads(environ["BUSYLIGHT_API_CORS_ORIGINS_LIST"])
+            logger.info("CORS list: {}".format(self.origins))
             logger.info("Found CORS allowed origins in environment.")
         except KeyError:
             logger.info("Did NOT find CORS allowed origins in environment.")

--- a/busylight/api/busylight_api.py
+++ b/busylight/api/busylight_api.py
@@ -1,6 +1,8 @@
 """BusyLight API
 """
 
+from contextvars import Context
+from multiprocessing import context
 from os import environ
 from secrets import compare_digest
 from typing import Callable, List, Dict, Any
@@ -62,7 +64,10 @@ busylightapi_security = HTTPBasic()
 class BusylightAPI(FastAPI):
     def __init__(self):
 
-        logger.info('GlobalOptions.debug: {}'.format(GlobalOptions.debug))
+        global_options = GlobalOptions(
+            debug = environ["BUSYLIGHT_DEBUG"]
+        )
+        logger.info('debug: {}'.format(global_options.debug))
 
         dependencies = []
         logger.info("Set up authentication, if environment variables set.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "busylight-for-humans"
-version = "0.21.1"
+version = "0.21.2"
 description = "Control USB connected LED lights, like a human."
 authors = ["JnyJny <erik.oshaughnessy@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Closes #161 

# Change description

This change adds support for the CORS `Access-Control-Allow-Origin` header.

That header is required if the API is accessed in a browser, via a host that is not the API host itself. 

For example: if a web UI were developed and hosted on a separate host than where the `busyserve` web API is running.

These changes have been manually tested.

# How to test

Run `busyserve` on host A.
On host B, run a web UI (simple page with javascript making a call to the web API on host A). 
Keep an eye on the browser javascript console: it should NOT show any CORS errors.