### PR TITLE
Call vendor function in udev-rules, increment index when printing

### DIFF
--- a/busylight/lights/hidlight.py
+++ b/busylight/lights/hidlight.py
@@ -66,10 +66,10 @@ class HIDLight(Light):
         ]
 
         devices = cls.supported_device_ids()
-        rules.append(f"# Rules for {cls.vendor} Family of Devices: {len(devices)}")
+        rules.append(f"# Rules for {cls.vendor()} Family of Devices: {len(devices)}")
         for n, ((vid, pid), name) in enumerate(devices.items()):
             logger.info(f"udev rule for {vid:04x}, {pid:04x} {name}")
-            rules.append(f"# {n} {cls.vendor} {name}")
+            rules.append(f"# {n+1} {cls.vendor()} {name}")
             for rule_format in rule_formats:
                 rules.append(rule_format.format(vid=vid, pid=pid, mode=mode))
 


### PR DESCRIPTION
The vendor function was merely being referenced, rather than called, resulting in the output including the repr rather than the string as intended.

This also bumps the index when printing to human-based counting, rather than zero-indexed, since it is, as you say, for humans. :-)

Before:
```
# Generated by `busylight udev-rules` https://github.com/JnyJny/busylight
#
# Rules for <function BlinkStick.vendor at 0x7f816e09d2d0> Family of Devices: 1
# 0 <function BlinkStick.vendor at 0x7f816e09d2d0> BlinkStick
KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="41e5", MODE="0666"
SUBSYSTEM=="usb", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="41e5", MODE="0666"
# Rules for <function Blynclight.vendor at 0x7f816e0c0280> Family of Devices: 3
# 0 <function Blynclight.vendor at 0x7f816e0c0280> Blynclight
KERNEL=="hidraw*", ATTRS{idVendor}=="2c0d", ATTRS{idProduct}=="0001", MODE="0666"
SUBSYSTEM=="usb", ATTRS{idVendor}=="2c0d", ATTRS{idProduct}=="0001", MODE="0666"
# 1 <function Blynclight.vendor at 0x7f816e0c0280> Blynclight
KERNEL=="hidraw*", ATTRS{idVendor}=="2c0d", ATTRS{idProduct}=="000c", MODE="0666"
SUBSYSTEM=="usb", ATTRS{idVendor}=="2c0d", ATTRS{idProduct}=="000c", MODE="0666"
# 2 <function Blynclight.vendor at 0x7f816e0c0280> Blynclight
KERNEL=="hidraw*", ATTRS{idVendor}=="0e53", ATTRS{idProduct}=="2516", MODE="0666"
SUBSYSTEM=="usb", ATTRS{idVendor}=="0e53", ATTRS{idProduct}=="2516", MODE="0666"
...snipped
```

After:
```
# Generated by `busylight udev-rules` https://github.com/JnyJny/busylight
#
# Rules for Agile Innovative Family of Devices: 1
# 1 Agile Innovative BlinkStick
KERNEL=="hidraw*", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="41e5", MODE="0666"
SUBSYSTEM=="usb", ATTRS{idVendor}=="20a0", ATTRS{idProduct}=="41e5", MODE="0666"
# Rules for Embrava Family of Devices: 3
# 1 Embrava Blynclight
KERNEL=="hidraw*", ATTRS{idVendor}=="2c0d", ATTRS{idProduct}=="0001", MODE="0666"
SUBSYSTEM=="usb", ATTRS{idVendor}=="2c0d", ATTRS{idProduct}=="0001", MODE="0666"
# 2 Embrava Blynclight
KERNEL=="hidraw*", ATTRS{idVendor}=="2c0d", ATTRS{idProduct}=="000c", MODE="0666"
SUBSYSTEM=="usb", ATTRS{idVendor}=="2c0d", ATTRS{idProduct}=="000c", MODE="0666"
# 3 Embrava Blynclight
KERNEL=="hidraw*", ATTRS{idVendor}=="0e53", ATTRS{idProduct}=="2516", MODE="0666"
SUBSYSTEM=="usb", ATTRS{idVendor}=="0e53", ATTRS{idProduct}=="2516", MODE="0666"
...snipped
```

Diff
```diff
3,4c3,4
< # Rules for <function BlinkStick.vendor at 0x7f816e09d2d0> Family of Devices: 1
< # 0 <function BlinkStick.vendor at 0x7f816e09d2d0> BlinkStick
---
> # Rules for Agile Innovative Family of Devices: 1
> # 1 Agile Innovative BlinkStick
7,8c7,8
< # Rules for <function Blynclight.vendor at 0x7f816e0c0280> Family of Devices: 3
< # 0 <function Blynclight.vendor at 0x7f816e0c0280> Blynclight
---
> # Rules for Embrava Family of Devices: 3
> # 1 Embrava Blynclight
11c11
< # 1 <function Blynclight.vendor at 0x7f816e0c0280> Blynclight
---
> # 2 Embrava Blynclight
14c14
< # 2 <function Blynclight.vendor at 0x7f816e0c0280> Blynclight
---
> # 3 Embrava Blynclight

```