### PR TITLE
Add support for Luxafor Bluetooth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ tst.py
 htmlcov
 *token
 .python-version
+
+.vscode/

--- a/busylight/lights/__init__.py
+++ b/busylight/lights/__init__.py
@@ -65,7 +65,7 @@ from .agile_innovative import BlinkStick
 from .compulab import Fit_StatUSB
 from .embrava import Blynclight, Blynclight_Mini, Blynclight_Plus
 from .kuando import Busylight_Alpha, Busylight_Omega
-from .luxafor import Flag, Mute, Orb
+from .luxafor import Flag, Mute, Orb, Bluetooth
 from .muteme import MuteMe, MuteMe_Mini
 from .mutesync import MuteSync
 from .plantronics import Status_Indicator
@@ -94,5 +94,6 @@ __all__ = [
     "MuteMe_Mini",
     "MuteSync",
     "Orb",
+    "Bluetooth",
     "Status_Indicator",
 ]

--- a/busylight/lights/luxafor/__init__.py
+++ b/busylight/lights/luxafor/__init__.py
@@ -4,6 +4,7 @@
 from .flag import Flag
 from .mute import Mute
 from .orb import Orb
+from .bluetooth import Bluetooth
 
 
-__all__ = ["Flag", "Mute", "Orb"]
+__all__ = ["Flag", "Mute", "Orb", "Bluetooth"]

--- a/busylight/lights/luxafor/bluetooth.py
+++ b/busylight/lights/luxafor/bluetooth.py
@@ -1,0 +1,13 @@
+""" Luxafor Bluetooth
+"""
+from typing import Dict, Tuple
+
+from .flag import Flag
+
+
+class Bluetooth(Flag):
+    @staticmethod
+    def supported_device_ids() -> Dict[Tuple[int, int], str]:
+        return {
+            (0x4D8, 0xF372): "BT",
+        }

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,13 +33,13 @@ The following is a technical review of each family of USB-connected
 lights; their capabilties, and difficulties encountered while adding
 support for them. These devices are accessible via the USB
 Human Interface Device (HID) application programming interface
-(API) or via a more traditional USB serial interface. 
+(API) or via a more traditional USB serial interface.
 
 - [Agile Innovative BlinkStick Family][6]
 - [Compulab fit-statUSB][9]
 - [Embrava Blynclight Family][2]
 - [Kuando BusyLight Family][3]
-- [Luxafor Flag, Orb and Mute][4]
+- [Luxafor Flag, Orb, Mute and Bluetooth][4]
 - [MuteMe MuteMe][7]
 - [MuteSync MuteSync][8]
 - [Plantronics Status Indicator][2]

--- a/docs/devices/luxafor.md
+++ b/docs/devices/luxafor.md
@@ -1,6 +1,6 @@
 ![BusyLight Project Logo][1]
 
-## Luxafor Flag 
+## Luxafor Flag
 
 The [Luxafor][0] line of products includes three USB connected presence
 lights: the Flag, the Mute and the Orb.
@@ -23,10 +23,12 @@ port, which can be used with the supplied adhesive-backed magnet to
 
 #### Luxafor Orb
 
+#### Luxafor Bluetooth
+
 ### Basic Human Interface Device Info
 
 - Vendor ID values:
-  - 0x04d8, 0xf372: Flag, Mute, Orb
+  - 0x04d8, 0xf372: Flag, Mute, Orb and Bluetooth
 - I/O Interface: `HID` write
 - Command Length: 8-bytes
 
@@ -34,8 +36,8 @@ port, which can be used with the supplied adhesive-backed magnet to
 
 The Luxafor family of lights are [USB HID][H] accessible devices whose
 attributes are controlled by writing an 8 byte packet to the device.
-All three devices share the same product/vendor identifier so they
-are discerned by the embedded product string; Flag, Mute or Orb.
+All four devices share the same product/vendor identifier so they
+are discerned by the embedded product string; Flag, Mute, Orb or BT.
 
 #### Steady Color Command
 ```C

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -109,6 +109,12 @@ HID_LIGHTS = [
         "product_string": "Orb",
     },
     {
+        "vendor_id": 0x04D8,
+        "product_id": 0xF372,
+        "path": b"/fake/path",
+        "product_string": "BT",
+    },
+    {
         "vendor_id": 0x16C0,
         "product_id": 0x27DB,
         "path": b"/fake/path",

--- a/tests/test_light_instances.py
+++ b/tests/test_light_instances.py
@@ -15,6 +15,7 @@ import busylight.lights.kuando.busylight_omega
 import busylight.lights.luxafor.flag
 import busylight.lights.luxafor.mute
 import busylight.lights.luxafor.orb
+import busylight.lights.luxafor.bluetooth
 
 from . import BOGUS_DEVICE_ID, PHYSICAL_LIGHT_SUBCLASSES, LightType, MockDevice
 


### PR DESCRIPTION
Add support for Luxafor Bluetooth (https://luxafor.com/product/bluetooth/), using the same pattern used for other Luxafor devices.