### PR TITLE
Created a generic adapter for serical CDC devices to connect with devices running custom CircuitPython program

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![version][pypi-version]
 ![monthly-downloads][monthly-downloads]
 ![visits][visits]
-![supported python versions][python-versions] 
+![supported python versions][python-versions]
 ![license][license]
 ![Code style: black][code-style-black]
 <br>
@@ -31,7 +31,7 @@ BlinkStick Square<sup>9</sup>,
 Blynclight Mini<sup>10</sup>,
 MuteMe Original<sup>11</sup>,
 fit-statUSB<sup>12</sup>,
-MuteSync<sup>13</sup>, 
+MuteSync<sup>13</sup>,
 Blynclight Plus<sup>14</sup>
 
 ## Features
@@ -58,7 +58,7 @@ If you have a USB light that's not on this list open an issue with:
  - the make and model device you want supported
  - where I can get one
  - any public hardware documentation you are aware of
- 
+
 Or even better, open a pull request!
 
 ### Gratitude
@@ -72,7 +72,7 @@ Installs only the command-line `busylight` tool and associated
 modules.
 
 ```console
-$ python3 -m pip install busylight-for-humans 
+$ python3 -m pip install busylight-for-humans
 ```
 
 ## Web API Install
@@ -95,7 +95,7 @@ I use the tool [poetry][poetry-docs] to manage various aspects of this project, 
 - publishing packages to PyPi
 
 ```console
-$ python3 -m pip install poetry 
+$ python3 -m pip install poetry
 $ cd path/to/busylight
 $ poetry shell
 <venv> $ poetry install -E webapi
@@ -214,7 +214,7 @@ Adding light support to your own python applications is easy!
 ### Simple Case: Turn On a Single Light
 
 In this example, we pick an Embrava Blynclight to activate with
-the color white. 
+the color white.
 
 ```python
 from busylight.lights.embrava import Blynclight
@@ -224,7 +224,7 @@ light = Blynclight.first_light()
 light.on((255, 255, 255))
 ```
 
-Not sure what light you've got? 
+Not sure what light you've got?
 
 ```python
 from busylight.lights import USBLight
@@ -247,7 +247,7 @@ from busylight.effects import Effects
 manager = LightManager()
 for light in manager.lights:
    print(light.name)
-   
+
 rainbow = Effects.for_name("spectrum")(duty_cycle=0.05)
 
 manager.apply_effect(rainbow)

--- a/busylight/lights/__init__.py
+++ b/busylight/lights/__init__.py
@@ -72,6 +72,7 @@ from .muteme import MuteMe, MuteMe_Mini
 from .mutesync import MuteSync
 from .plantronics import Status_Indicator
 from .thingm import Blink1
+from .freemansoft import Adafruit_TrinkeyNeo
 
 
 __all__ = [
@@ -97,6 +98,7 @@ __all__ = [
     "MuteSync",
     "Orb",
     "Status_Indicator",
+    "Adafruit_TrinkeyNeo",
 ]
 
 logger.disable("busylight.lights")

--- a/busylight/lights/freemansoft/__init__.py
+++ b/busylight/lights/freemansoft/__init__.py
@@ -1,0 +1,7 @@
+"""
+Adafruit Trinkey Neo with Freemansoft Firmware
+"""
+
+from .adafruit_trinkey_neo import Adafruit_TrinkeyNeo
+
+__all__ = ["Adafruit_TrinkeyNeo"]

--- a/busylight/lights/freemansoft/adafruit_trinkey_neo.py
+++ b/busylight/lights/freemansoft/adafruit_trinkey_neo.py
@@ -1,0 +1,26 @@
+"""
+"""
+
+from typing import Dict, Tuple
+
+from loguru import logger
+
+from ..seriallight import SerialLight
+
+
+class Adafruit_TrinkeyNeo(SerialLight):
+    @staticmethod
+    def supported_device_ids() -> Dict[Tuple[int, int], str]:
+        return {
+            (0x239A, 0x0080): "Adafruit-TrinkeyNeo",
+        }
+
+    @staticmethod
+    def vendor() -> str:
+        return "Adafruit"
+
+    def __bytes__(self) -> bytes:
+        # all pixels
+        buf = f"#ff{self.red:02x}{self.green:02x}{self.blue:02x}\n"
+
+        return buf.encode()

--- a/busylight/lights/freemansoft/adafruit_trinkey_neo.py
+++ b/busylight/lights/freemansoft/adafruit_trinkey_neo.py
@@ -12,7 +12,7 @@ class Adafruit_TrinkeyNeo(SerialLight):
     @staticmethod
     def supported_device_ids() -> Dict[Tuple[int, int], str]:
         return {
-            (0x239A, 0x0080): "Adafruit-TrinkeyNeo",
+            (0x239A, 0x80f0): "Adafruit-TrinkeyNeo",
         }
 
     @staticmethod

--- a/docs/devices/freemansoft.md
+++ b/docs/devices/freemansoft.md
@@ -22,7 +22,43 @@ the female USB plug.
 ### USB Device Info
 
 - Vendor/Product ID values:
-   - 0x239A, 0x0080: ???
+   - 0x239A, 0x80f0: NeoPixel Trinkey M0
+
+On the mac you see something like
+
+```
+NeoPixel Trinkey M0:
+
+   Product ID: 0x80f0
+   Vendor ID: 0x239a
+   Version: 1.00
+   Serial Number: CA1747C34B48585020312E3521280EFF
+   Speed: Up to 12 Mb/s
+   Manufacturer: Adafruit Industries LLC
+   Location ID: 0x02100000 / 1
+   Current Available (mA): 500
+   Current Required (mA): 100
+   Extra Operating Current (mA): 0
+   Media:
+   NeoPixel Trinkey:
+      Capacity: 66 KB (66,048 bytes)
+      Removable Media: Yes
+      BSD Name: disk4
+      Logical Unit: 0
+      Partition Map Type: MBR (Master Boot Record)
+      S.M.A.R.T. status: Verified
+      USB Interface: 2
+      Volumes:
+         CIRCUITPY:
+         Capacity: 66 KB (65,536 bytes)
+         Free: 32 KB (32,256 bytes)
+         Writable: Yes
+         File System: MS-DOS FAT12
+         BSD Name: disk4s1
+         Mount Point: /Volumes/CIRCUITPY
+         Content: DOS_FAT_12
+         Volume UUID: D9E0500C-524E-39A8-A778-C125384249C0
+```
 
 ### Device Operation
 

--- a/docs/devices/freemansoft.md
+++ b/docs/devices/freemansoft.md
@@ -1,0 +1,48 @@
+![Busylight Project Logo][L]
+
+## FreemanSoft Generic for Custom firmware
+
+This is a driver for devices running custom firmware that
+communicates over a USB serial port.  The firmware is written
+in CircuitPython and supports any board with a board.NEOPIXEL definition.
+It was tested with the Adafruit Trinkey Neo with for Neopixels
+running freemansoft derived firmware.
+
+### Physical Description
+
+The test device is the size of a USB thumb drive and is designed as a programmable device
+
+#### Adafruit Trinkey Neo
+
+The fit-statUSB is a very small device with two LEDs mounted on the
+dorsal and ventral sides of it's PCB. The entire package is A cm wide,
+B cm high, and C cm long, the majority of the device residing inside
+the female USB plug.
+
+### USB Device Info
+
+- Vendor/Product ID values:
+   - 0x239A, 0x0080: ???
+
+### Device Operation
+
+The Circuit Python devices are accessed via a more traditional serial port rather
+than the USB Human Interface Device used by the majority of status
+light products. The device is still identifiable via conventional
+sixteen bit vendor and product identifiers.
+
+### Command Format
+
+See [firmware docs on github](https://github.com/freemansoft/Adafruit-Trinkey-CircuitPython/tree/main/Indicator-Light-neopixel)
+
+#### Turning the Light On
+
+#### Turning the Light Off
+
+### Observations
+
+
+[0]: _add link here_
+
+[L]: ../assets/Unstacked-Logo-Light.png
+[S]: https://github.com/pyserial/pyserial

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "busylight-for-humans"
-version = "0.26.0"
+version = "0.27.0"
 description = "Control USB connected LED lights, like a human."
 authors = ["JnyJny <erik.oshaughnessy@gmail.com>"]
 license = "Apache-2.0"

--- a/tests/test_light_instances.py
+++ b/tests/test_light_instances.py
@@ -16,7 +16,7 @@ import busylight.lights.luxafor.bluetooth
 import busylight.lights.luxafor.flag
 import busylight.lights.luxafor.mute
 import busylight.lights.luxafor.orb
-
+import busylight.lights.freemansoft.adafruit_trinkey_neo
 
 from . import BOGUS_DEVICE_ID, PHYSICAL_LIGHT_SUBCLASSES, LightType, MockDevice
 


### PR DESCRIPTION
I can't seem to get busylight to pick up my new device when I run `busylight supported`.  I thought this meant it wasn't picking up my drivers. Then I incremented the version number and the command `busylight --version` does not reflect the incremented numbers.  It looks like it is running the installed busylight and not the one from my git repo.

The instructions say the following. I'm assuming this is the top of the busylight git repo.
> cd path/to/busylight

Any ideas off the top of your head?

```
PS C:\Users\joe\Documents\GitHub\busylight> poetry shell
Spawning shell within C:\Users\joe\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\LocalCache\Local\pypoetry\Cache\virtualenvs\busylight-for-humans-qGfsEWtE-py3.9
Windows PowerShell
Copyright (C) Microsoft Corporation. All rights reserved.

Install the latest PowerShell for new features and improvements! https://aka.ms/PSWindows

(busylight-for-humans-py3.9) PS C:\Users\joe\Documents\GitHub\busylight> busylight --version
0.26.0
(busylight-for-humans-py3.9) PS C:\Users\joe\Documents\GitHub\busylight> 
```

Maybe this should have been under issues because it was environment but I did a pull request in case there is a code change that I need to make to pick up the environment or version.