### PR TITLE
Added first draft for a systemd-unitfile in the contrib

### DIFF
--- a/contrib/busylight-busyserve.service
+++ b/contrib/busylight-busyserve.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Busylight API Server
+
+[Service]
+ExecStart=screen -m -d -S systemD_busylight /usr/local/bin/busyserve -D
+ExecStartPost=/bin/curl --retry-connrefused --retry 5 --connect-timeout 5 -s "http://localhost:8000/lights/rainbow?speed=slow"
+KillMode=control-group
+Type=forking
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
I know, this file is not perfect, but it works.
I think the problem with the busyserve command is that it sends no "Success"-signal back to the main process, thats why I added the screen-command. I did this with many proprietary gameservers hosted on linux and thats fine, at least for me. Update / Improve if you wish.

The ExecStartPost can be customized to anyone's wishes of course, I added the retry and connect-timeout parameters because the Port is not available immediately at the time of EcexStartPost execution. I did not want to add a bash script (which sleeps a short time and then curls the server), but that were possible, too.

This file can be copied to `/usr/lib/systemd/system/` or `/etc/systemd/system/`.

This PR also kind of resolveds https://github.com/JnyJny/busylight/issues/84