### PR TITLE
Added missing device ID for kuando busylight alpha

### DIFF
--- a/busylight/lights/kuando/busylight_alpha.py
+++ b/busylight/lights/kuando/busylight_alpha.py
@@ -20,6 +20,7 @@ class Busylight_Alpha(HIDLight):
             (0x04D8, 0xF848): "Busylight Alpha",
             (0x27BB, 0x3BCA): "Busylight Alpha",
             (0x27BB, 0x3BCE): "Busylight Alpha",
+            (0x27BB, 0x3BCB): "Busylight Alpha",
         }
 
     @staticmethod


### PR DESCRIPTION
There was an ID missing for my kuando busylight alpha device, this PR adds the ID.

Without ID:

```bash
➜  busylight git:(master) busylight on
No lights to turn on.
```

With ID added:
``` bash
➜  busylight git:(master) ✗ busylight list
  0 Busylight Alpha
  1 Busylight Alpha
  2 Busylight Alpha
```

<img width="350" alt="Screenshot 2024-05-30 at 13 59 04" src="https://github.com/JnyJny/busylight/assets/29383712/10a8b840-ad94-421d-8580-16f1293e909d">
