### PR TITLE
fix: building a wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,8 +97,8 @@ cmd = "rm -rf htmlcov dist busylight.egg-info *.log"
 addopts = "-p no:warnings"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
 
 [mypy]
 [mypy-webcolors]


### PR DESCRIPTION
this fixes two issues when building a wheel using pyproject-build. The first issue
```
ERROR Missing dependencies:
  poetry>=0.12
```
can be resolved by requiring poetry-core over poetry>=0.12

The second issue
```
ModuleNotFoundError: No module named 'poetry.masonry'
```
can be resolved by importing the correct module from poetry.core.

see also https://pypi.org/project/poetry-core/