### PR TITLE
Add Support for SIA Busy Tag

### DIFF
--- a/busylight/lights/__init__.py
+++ b/busylight/lights/__init__.py
@@ -72,6 +72,7 @@ from .muteme import MuteMe, MuteMe_Mini
 from .mutesync import MuteSync
 from .plantronics import Status_Indicator
 from .thingm import Blink1
+from .siabusytag import SiaBusyTag
 
 
 __all__ = [
@@ -96,6 +97,7 @@ __all__ = [
     "MuteMe_Mini",
     "MuteSync",
     "Orb",
+    "SiaBusyTag",
     "Status_Indicator",
 ]
 

--- a/busylight/lights/siabusytag/__init__.py
+++ b/busylight/lights/siabusytag/__init__.py
@@ -1,0 +1,9 @@
+"""SIA Busy Tag Support
+
+https://www.busy-tag.com/
+
+"""
+
+from .sia_busy_tag import SiaBusyTag
+
+__all__ = ["SiaBusyTag"]

--- a/busylight/lights/siabusytag/sia_busy_tag.py
+++ b/busylight/lights/siabusytag/sia_busy_tag.py
@@ -1,0 +1,30 @@
+"""
+"""
+
+from typing import Dict, Tuple
+
+from loguru import logger
+
+from ..seriallight import SerialLight
+
+
+class SiaBusyTag(SerialLight):
+    @staticmethod
+    def supported_device_ids() -> Dict[Tuple[int, int], str]:
+        return {
+            (0x303a, 0x81df): "GREYNUT LTD BUSY TAG",
+        }
+
+    @staticmethod
+    def vendor() -> str:
+        return "SIA Busy Tag"
+
+    def __bytes__(self) -> bytes:
+
+        # Change Color using AT Serial Commands 
+        # See for reference:
+        # https://luxafor.helpscoutdocs.com/article/47-busy-tag-usb-cdc-command-reference-guide
+        # AT+SC=127,<hex color>
+        buf = f"AT+SC=127,{self.red:02x}{self.green:02x}{self.blue:02x}"
+
+        return buf.encode()


### PR DESCRIPTION
This PR adds basic LED support for SIA Busy Tag.

Basic as in:

* addressing all LEDs only (7 LEDs are present)
* no support for the integrated LCD Display

https://www.busy-tag.com/

LED can be controlled using serial connection and AT commands as descibed in this guide: https://luxafor.helpscoutdocs.com/article/47-busy-tag-usb-cdc-command-reference-guide