### PR TITLE
Add ability to specify number of blinks, pulses, or flashes

### DIFF
--- a/busylight/__main__.py
+++ b/busylight/__main__.py
@@ -176,11 +176,14 @@ def blink_lights(
         Speed.Slow,
         show_default=True,
     ),
+    count: int | None = typer.Argument(
+        None, show_default="no limit"
+    ),
 ) -> None:
     """Blink light on and off."""
     logger.info("blinking lights")
 
-    blink = Effects.for_name("blink")(color, speed.duty_cycle)
+    blink = Effects.for_name("blink")(color, speed.duty_cycle, count=count)
 
     try:
         manager.apply_effect(blink, ctx.obj.lights, timeout=ctx.obj.timeout)
@@ -219,10 +222,13 @@ def pulse_lights(
         "red", callback=string_to_scaled_color, show_default=True
     ),
     speed: Speed = typer.Argument(Speed.Slow, show_default=True),
+    count: int | None = typer.Argument(
+        None, show_default="no limit"
+    ),
 ) -> None:
     """Pulse light on and off."""
     logger.info("applying gradient effect")
-    throb = Effects.for_name("gradient")(color, speed.duty_cycle / 16, 8)
+    throb = Effects.for_name("gradient")(color, speed.duty_cycle / 16, 8, count=count)
     try:
         manager.apply_effect(throb, ctx.obj.lights, timeout=ctx.obj.timeout)
     except (KeyboardInterrupt, TimeoutError):
@@ -246,10 +252,13 @@ def flash_lights_impressively(
         show_default=True,
     ),
     speed: Speed = typer.Argument(Speed.Slow),
+    count: int | None = typer.Argument(
+        None, show_default="no limit"
+    ),
 ) -> None:
     """Flash lights impressively between two colors."""
     logger.info("applying fli effect")
-    fli = Effects.for_name("blink")(color_a, speed.duty_cycle / 10, off_color=color_b)
+    fli = Effects.for_name("blink")(color_a, speed.duty_cycle / 10, off_color=color_b, count=count)
 
     try:
         manager.apply_effect(fli, ctx.obj.lights, timeout=ctx.obj.timeout)

--- a/busylight/api/busylight_api.py
+++ b/busylight/api/busylight_api.py
@@ -397,6 +397,7 @@ async def blink_light(
     color: str = "red",
     speed: Speed = Speed.Slow,
     dim: float = 1.0,
+    count: int | None = None,
 ) -> Dict[str, Any]:
     """Start blinking the specified light: color and off.
 
@@ -405,11 +406,13 @@ async def blink_light(
 
     The `color` can be a color name or a hexadecimal string: red,
     #ff0000, #f00, 0xff0000, 0xf00, f00, ff0000
+
+    `count` is the number of times to blink the light.
     """
 
     rgb = parse_color_string(color, dim)
 
-    effect = Effects.for_name("blink")(rgb, speed.duty_cycle)
+    effect = Effects.for_name("blink")(rgb, speed.duty_cycle, count=count)
 
     await busylightapi.apply_effect(effect, light_id)
 
@@ -420,6 +423,7 @@ async def blink_light(
         "rgb": rgb,
         "speed": speed,
         "dim": dim,
+        "count": count,
     }
 
 
@@ -431,6 +435,7 @@ async def blink_lights(
     color: str = "red",
     speed: Speed = Speed.Slow,
     dim: float = 1.0,
+    count: int | None = None,
 ) -> Dict[str, Any]:
     """Start blinking all the lights: red and off
     <p>Note: lights will not be synchronized.</p>
@@ -438,7 +443,7 @@ async def blink_lights(
 
     rgb = parse_color_string(color, dim)
 
-    blink = Effects.for_name("blink")(rgb, speed.duty_cycle)
+    blink = Effects.for_name("blink")(rgb, speed.duty_cycle, count=count)
 
     await busylightapi.apply_effect(blink)
 
@@ -449,6 +454,7 @@ async def blink_lights(
         "rgb": rgb,
         "speed": speed,
         "dim": dim,
+        "count": count,
     }
 
 
@@ -514,17 +520,20 @@ async def flash_light_impressively(
     color_b: str = "blue",
     speed: Speed = Speed.Slow,
     dim: float = 1.0,
+    count: int | None = None,
 ) -> Dict[str, Any]:
     """Flash the specified light impressively [default: red/blue].
 
     `light_id` is an integer value identifying a light and ranges
     between zero and number_of_lights-1.
+
+    `count` is the number of times to blink the light.
     """
 
     rgb_a = parse_color_string(color_a, dim)
     rgb_b = parse_color_string(color_b, dim)
 
-    fli = Effects.for_name("blink")(rgb_a, speed.duty_cycle / 10, off_color=rgb_b)
+    fli = Effects.for_name("blink")(rgb_a, speed.duty_cycle / 10, off_color=rgb_b, count=count)
 
     await busylightapi.apply_effect(fli, light_id)
 
@@ -535,6 +544,7 @@ async def flash_light_impressively(
         "speed": speed,
         "color": color_a,
         "dim": dim,
+        "count": count,
     }
 
 
@@ -547,13 +557,14 @@ async def flash_lights_impressively(
     color_b: str = "blue",
     speed: Speed = Speed.Slow,
     dim: float = 1.0,
+    count: int | None = None,
 ):
     """Flash all lights impressively [default: red/blue]"""
 
     rgb_a = parse_color_string(color_a, dim)
     rgb_b = parse_color_string(color_b, dim)
 
-    fli = Effects.for_name("blink")(rgb_a, speed.duty_cycle / 10, off_color=rgb_b)
+    fli = Effects.for_name("blink")(rgb_a, speed.duty_cycle / 10, off_color=rgb_b, count=count)
 
     await busylightapi.apply_effect(fli)
 
@@ -564,6 +575,7 @@ async def flash_lights_impressively(
         "speed": speed,
         "color": color_a,
         "dim": dim,
+        "count": count,
     }
 
 
@@ -576,15 +588,18 @@ async def pulse_light(
     color: str = "red",
     speed: Speed = Speed.Slow,
     dim: float = 1.0,
+    count: int | None = None,
 ) -> Dict[str, Any]:
     """Pulse a light with a specified color [default: red].
 
     `light_id` is an integer value identifying a light and ranges
     between zero and number_of_lights-1.
+
+    `count` is the number of times to blink the light.
     """
     rgb = parse_color_string(color, dim)
 
-    throb = Effects.for_name("Gradient")(rgb, speed.duty_cycle / 16, 8)
+    throb = Effects.for_name("Gradient")(rgb, speed.duty_cycle / 16, 8, count=count)
 
     await busylightapi.apply_effect(throb, light_id)
 
@@ -596,6 +611,7 @@ async def pulse_light(
         "rgb": rgb,
         "speed": speed,
         "dim": dim,
+        "count": count,
     }
 
 
@@ -607,12 +623,13 @@ async def pulse_lights(
     color: str = "red",
     speed: Speed = Speed.Slow,
     dim: float = 1.0,
+    count: int | None = None,
 ):
     """Pulse all lights with a color [default: red]."""
 
     rgb = parse_color_string(color, dim)
 
-    throb = Effects.for_name("Gradient")(rgb, speed.duty_cycle / 16, 8)
+    throb = Effects.for_name("Gradient")(rgb, speed.duty_cycle / 16, 8, count=count)
 
     await busylightapi.apply_effect(throb)
 
@@ -624,4 +641,5 @@ async def pulse_lights(
         "speed": speed,
         "rgb": rgb,
         "dim": dim,
+        "count": count,
     }

--- a/busylight/effects/blink.py
+++ b/busylight/effects/blink.py
@@ -13,18 +13,22 @@ class Blink(BaseEffect):
         on_color: Tuple[int, int, int],
         duty_cycle: float,
         off_color: Tuple[int, int, int] = None,
+        count = None,
     ) -> None:
         """This effect turns a light on and off with the specified color(s),
-        pausing for `duty_cycle` seconds in between each operation.
+        pausing for `duty_cycle` seconds in between each operation. If count is
+        given (and is not None), the light will blink count times.
 
         :param on_color: Tuple[int,int,int]
         :param duty_cycle: float
         :param off_color: Tuple[int,int,int] defaults to black.
+        :param count: int defaults to None, indicating no limit.
         """
 
         self.on_color = on_color
         self.off_color = off_color or (0, 0, 0)
         self.duty_cycle = duty_cycle
+        self.count = count
 
     def __repr__(self) -> str:
         return f"{self.name}(on_color={self.on_color!r}, duty_cycle={self.duty_cycle!r}, off_color={self.off_color!r})"

--- a/busylight/effects/gradient.py
+++ b/busylight/effects/gradient.py
@@ -11,7 +11,8 @@ from .effect import BaseEffect
 class Gradient(BaseEffect):
     """This effect will produce a color range from black to the
     given color and then back to black again with the given number
-    of steps between off and on.
+    of steps between off and on. If count is given (and is not None),
+    the light will go through this sequence count times.
     """
 
     def __init__(
@@ -19,11 +20,13 @@ class Gradient(BaseEffect):
         color: Tuple[int, int, int],
         duty_cycle: float,
         step: int = 1,
+        count = None,
     ) -> None:
         """
         :param color: Tuple[int,int,int]
         :param duty_cycle: float
         :param step: int
+        :param count: int defaults to None, indicating no limit.
         """
 
         self.color = color
@@ -31,6 +34,7 @@ class Gradient(BaseEffect):
         # XXX need to choose steps that make sense for scaled colors
         #     where the max(color) << 255
         self.step = max(0, min(step, 255))
+        self.count = count
 
     @property
     def colors(self) -> List[Tuple[int, int, int]]:

--- a/tests/test_effect_blink.py
+++ b/tests/test_effect_blink.py
@@ -7,15 +7,15 @@ from busylight.effects import Blink
 
 
 @pytest.mark.parametrize(
-    "on_color,duty_cycle,off_color",
+    "on_color,duty_cycle,off_color,count",
     [
-        ((255, 255, 255), 0.22, None),
-        ((128, 255, 32), 0.22, (32, 32, 32)),
+        ((255, 255, 255), 0.22, None, 3),
+        ((128, 255, 32), 0.22, (32, 32, 32), None),
     ],
 )
-def test_blink_init(on_color, duty_cycle, off_color) -> None:
+def test_blink_init(on_color, duty_cycle, off_color, count) -> None:
 
-    instance = Blink(on_color, duty_cycle, off_color)
+    instance = Blink(on_color, duty_cycle, off_color, count)
 
     assert instance.name == "Blink"
 
@@ -25,6 +25,7 @@ def test_blink_init(on_color, duty_cycle, off_color) -> None:
     assert isinstance(instance, Blink)
     assert instance.on_color == on_color
     assert instance.duty_cycle == duty_cycle
+    assert instance.count == count
 
     assert on_color in instance.colors
     assert repr(on_color) in repr_result

--- a/tests/test_effect_gradient.py
+++ b/tests/test_effect_gradient.py
@@ -7,14 +7,14 @@ from busylight.effects import Gradient
 
 
 @pytest.mark.parametrize(
-    "color,duty_cycle,step",
+    "color,duty_cycle,step,count",
     [
-        ((255, 255, 255), 0.5, 1),
+        ((255, 255, 255), 0.5, 1, None),
     ],
 )
-def test_effect_gradient_init(color, duty_cycle, step) -> None:
+def test_effect_gradient_init(color, duty_cycle, step, count) -> None:
 
-    instance = Gradient(color, duty_cycle, step)
+    instance = Gradient(color, duty_cycle, step, count)
 
     repr_result = repr(instance)
     str_result = str(instance)
@@ -24,6 +24,7 @@ def test_effect_gradient_init(color, duty_cycle, step) -> None:
 
     assert instance.duty_cycle == duty_cycle
     assert instance.step == step
+    assert instance.count == count
 
     assert instance.name in repr_result
     assert instance.name in str_result


### PR DESCRIPTION
For my use case, I'd like to specify the number of blinks. While I can definitely achieve the same effect using a timeout, I think a dedicated `count` parameter is cleaner. This PR implements just that (pulses and flashes follow the same pattern, so included those too). Hopefully this is useful for others too and fits the scope and intended design of this project.

Python is not my everyday language, so I'm not overly familiar with the ecosystem and conventions. I'm happy to iterate on this if there's a better way to do it though.