### PR TITLE
Fix README: correct blue color example from #00ff00 to #0000ff

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ $ busylight on
 $ busylight on               # light turns on green
 $ busylight on red           # now it's shining a friendly red
 $ busylight on 0xff0000      # still red
-$ busylight on #00ff00       # now it's blue!
+$ busylight on #0000ff       # now it's blue!
 $ busylight blink            # it's slowly blinking on and off with a red color
 $ busylight blink green fast # blinking faster green and off
 $ busylight --all on         # turn all lights on green


### PR DESCRIPTION
Corrects hex color code in command example. #00ff00 is green, not blue. Changed to #0000ff to match the "now it's blue!" comment.