### PR TITLE
Fix CLI to work without webapi extras

### DIFF
--- a/src/busylight/__main__.py
+++ b/src/busylight/__main__.py
@@ -6,7 +6,6 @@ import typer
 from loguru import logger
 
 from . import __version__
-from .busyserve import busyserve_cli
 from .callbacks import string_to_scaled_color
 from .global_options import GlobalOptions
 from .manager import LightManager
@@ -18,7 +17,13 @@ cli = typer.Typer()
 for subcommand in subcommands:
     cli.add_typer(subcommand)
 
-cli.add_typer(busyserve_cli)
+# Conditionally add busyserve CLI if webapi dependencies are available
+try:
+    from .busyserve import busyserve_cli
+    cli.add_typer(busyserve_cli)
+except ImportError:
+    # webapi extras not installed, skip busyserve functionality
+    pass
 
 webcli = typer.Typer()
 

--- a/src/busylight/busyserve.py
+++ b/src/busylight/busyserve.py
@@ -5,15 +5,14 @@ from os import environ
 import typer
 from loguru import logger
 
+# Check if webapi dependencies are available, fail import if not
 try:
     import uvicorn
 except ImportError as error:
-    logger.error(f"import uvicorn failed: {error}")
-    typer.secho(
-        "The package `uvicorn` is missing, unable to serve the busylight API.",
-        fg="red",
-    )
-    raise typer.Exit(code=1) from None
+    raise ImportError(
+        "The package `uvicorn` is missing, unable to serve the busylight API. "
+        "Install with webapi extras: pip install busylight-for-humans[webapi]"
+    ) from error
 
 busyserve_cli = typer.Typer()
 


### PR DESCRIPTION
## Summary

- Fixes CLI to work without webapi extras installed
- Resolves `uvx --with busylight-for-humans busylight` failure
- Maintains full functionality when webapi extras are installed

## Problem

The CLI was failing when used via `uvx --with busylight-for-humans busylight` because it attempted to import `busyserve_cli` unconditionally, which depends on `uvicorn` from the optional `[webapi]` extras group. This created a hard dependency on webapi components even for basic light control operations.

## Solution

Implemented conditional imports and import-time validation:

1. **Conditional CLI registration** in `__main__.py`:
   - Wrapped `busyserve_cli` import in try/except block
   - Only adds busyserve subcommand when webapi dependencies are available
   - Gracefully degrades when extras are missing

2. **Import-time validation** in `busyserve.py`:
   - Moved dependency check to import time
   - Provides clear error message with installation instructions
   - Prevents module loading when dependencies are missing

## Changes Made

### `/src/busylight/__main__.py`
- Removed unconditional import of `busyserve_cli`
- Added conditional import with try/except handling
- CLI gracefully excludes busyserve functionality when webapi extras unavailable

### `/src/busylight/busyserve.py`
- Moved uvicorn import check to module level
- Converted runtime error to ImportError for proper exception handling
- Enhanced error message with clear installation instructions

## Testing

- ✅ CLI works without webapi extras: `uvx --with busylight-for-humans busylight --help`
- ✅ CLI works with webapi extras: full busyserve functionality available
- ✅ Clear error messages guide users when extras needed
- ✅ No regression in existing functionality

## User Impact

- **Before**: CLI failed completely without webapi extras installed
- **After**: CLI works for all light control operations; webapi features gracefully unavailable
- Users get clear guidance on installing extras when attempting to use web functionality
- Maintains backwards compatibility for existing installations with webapi extras

🤖 Generated with [Claude Code](https://claude.ai/code)