### PR TITLE
feat: bump busylight-core to 1.0+ and add new Embrava devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ Blynclight Plus<sup>14</sup>
 - HTTP API with full documentation and authentication support  
 - Individual LED control for multi-LED devices (Blink1 mk2, Flag variants, BlinkStick variants)
 - Cross-platform support: macOS and Linux (Windows in development)
-- Support for 23 devices from 9 vendors:
+- Support for 26 devices from 9 vendors:
 
 | **Vendor** |  **Models** | **LED Support** |
 |------------|-------------|-----------------|
 | [**Agile Innovative**][2] | BlinkStick, BlinkStick Pro, BlinkStick Square, BlinkStick Strip, BlinkStick Nano, BlinkStick Flex | Multi-LED targeting |
 | [**Compulab**][8] | fit-statUSB | Single LED |
 | [**EPOS**][11] | Busylight | Single LED |
-| [**Embrava**][3] | Blynclight, Blynclight Mini, Blynclight Plus | Single LED |
+| [**Embrava**][3] | Blynclight, Blynclight Mini, Blynclight Plus, Blynclight BLYNCUSB10, Blynclight BLYNCUSB20 | Single LED |
 | [**Kuando**][4] | Busylight Alpha, BusyLight Omega | Single LED |
 | [**Luxafor**][5] | Bluetooth, Flag, Mute, Orb, Busy Tag | Multi-LED / Single LED |
 | [**Plantronics**][3] | Status Indicator | Single LED |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 repository = "https://github.com/JnyJny/busylight.git"
 requires-python = ">=3.11,<4.0"
 dependencies = [
-    "busylight-core>=0.8.0",
+    "busylight-core>=1.0.1",
     "hidapi>=0.14.0.post4",
     "loguru>=0.7.3",
     "pyserial>=3.5",

--- a/uv.lock
+++ b/uv.lock
@@ -27,16 +27,16 @@ wheels = [
 
 [[package]]
 name = "busylight-core"
-version = "0.15.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hidapi" },
     { name = "loguru" },
     { name = "pyserial" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/87/4b/39bad25a430359295b540cf38517b69277a0b28b1bc52be9fd90f294de3a/busylight_core-0.15.0.tar.gz", hash = "sha256:3e528ae022862ff30a7a310cf47e4e8d5f228ce6f2b7e4f5547f9cd732382de4", size = 40085, upload-time = "2025-07-31T20:11:22.842Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/a2/3cd202be9d044d6c7c720a911daead9d8b9fd520fb5d56dad5a2c752ef70/busylight_core-2.0.0.tar.gz", hash = "sha256:48a3347160245161c3019957f329db38c150f2b28333b41830aafc973c8cba22", size = 43909, upload-time = "2026-03-15T17:44:39.32Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/91/32a4be4fd6a602371c2a76c14109ed828bf1f9b75c4304974b6957bffa15/busylight_core-0.15.0-py3-none-any.whl", hash = "sha256:293ae82943ef4682d72f183991227d6c34fd564b0fd4096da328c93bf5dc1146", size = 74917, upload-time = "2025-07-31T20:11:21.434Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/ca/ff2200510d2ab44e6eedb918b39247c2046a58182ac2766fd0742f1b8d6c/busylight_core-2.0.0-py3-none-any.whl", hash = "sha256:9611b36a6e76c037674fcb7f88ee9a7a9121dc6ae5ae70a73c11289cf8f095bc", size = 81597, upload-time = "2026-03-15T17:44:38.074Z" },
 ]
 
 [[package]]
@@ -76,7 +76,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "busylight-core", specifier = ">=0.8.0" },
+    { name = "busylight-core", specifier = ">=1.0.1" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.115.14" },
     { name = "fastapi", marker = "extra == 'webapi'", specifier = ">=0.115.14" },
     { name = "hidapi", specifier = ">=0.14.0.post4" },


### PR DESCRIPTION
Update busylight-core dependency and README for the new 1.0 release.

## Changes

- **busylight-core dep:** `>=0.8.0` -> `>=1.0.1`
- **README:** Add Blynclight BLYNCUSB10 and BLYNCUSB20 to Embrava row, update device count from 23 to 26
- **uv.lock:** Synced

## New devices

Early Blynclight models (VID 0x1130) added in busylight-core 1.0:
- **BLYNCUSB10:** 8-byte feature report protocol
- **BLYNCUSB20:** TENX20 two-step HID write protocol

These are palette-based devices (color lookup table rather than direct RGB).

Authored by Jny