### PR TITLE
feat: replace auto-generate-changelog with git-cliff

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,12 +25,11 @@ jobs:
         python-version: ['3.11', '3.12', '3.13']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv and set Python version.
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
-          version: "latest"
           python-version: ${{ matrix.python-version }}
 
       - name: Install libusb on Linux.
@@ -42,7 +41,6 @@ jobs:
       - name: Run tests - ${{ matrix.python-version }} - ${{ matrix.os }}
         run: |
           uv run --all-extras pytest
-    
 
 
   publish:
@@ -59,13 +57,10 @@ jobs:
       url: https://pypi.org/project/busylight-for-humans
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Install uv and set Python version.
-        uses: astral-sh/setup-uv@v6
-        with:
-          version: "latest"
-          python-version: 3.13
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
 
       - name: Build package.
         run: |
@@ -83,71 +78,66 @@ jobs:
       !endsWith(github.ref, '-test') &&
       success()
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          fetch-depth: 100  # Limit history fetch for performance
-      - name: Auto-generate Changelog  
-        uses: BobAnkh/auto-generate-changelog@v1.2.5  # Latest available version
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Generate release notes for this tag
+        run: uv run git cliff --latest --strip header > release_notes.md
+
+      - name: Update CHANGELOG.md
+        run: uv run git cliff --output CHANGELOG.md
+
+      - name: Commit updated CHANGELOG.md
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git diff --cached --quiet || git commit -m "docs(CHANGELOG): update release notes"
+          git push origin HEAD:main
+
+      - name: Upload release notes
+        uses: actions/upload-artifact@v4
         with:
-          REPO_NAME: 'JnyJny/busylight'
-          ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PATH: 'CHANGELOG.md'
-          COMMIT_MESSAGE: 'docs(CHANGELOG): update release notes'
-          TYPE: 'feat:Feature,fix:Bug Fixes,docs:Documentation,refactor:Refactor,perf:Performance Improvements'
+          name: release-notes
+          path: release_notes.md
+          retention-days: 1
 
   github-release:
     name: Create GitHub Release
-    needs: publish
+    needs: [publish, generate-changelog]
     if: |
       github.ref_type == 'tag' &&
       startsWith(github.ref, 'refs/tags/v') &&
       !endsWith(github.ref, '-test') &&
       success()
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 50  # Limit history for performance
+        uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          python-version: 3.13
+        uses: astral-sh/setup-uv@v7
 
       - name: Build package
         run: |
           uv build
 
-      - name: Generate release notes
-        id: release_notes
-        run: |
-          # Get the tag name
-          TAG_NAME=${GITHUB_REF#refs/tags/}
-          
-          # Get the previous tag (limit to recent tags for performance)
-          PREVIOUS_TAG=$(git tag --sort=-version:refname | head -n 2 | tail -n 1 2>/dev/null || echo "")
-          
-          # Generate changelog with limited commits (last 50)
-          if [[ -n "$PREVIOUS_TAG" && "$PREVIOUS_TAG" != "$TAG_NAME" ]]; then
-            echo "## Changes since $PREVIOUS_TAG" >> release_notes.md
-            echo "" >> release_notes.md
-            git log --max-count=50 --pretty=format:"- %s (%h)" ${PREVIOUS_TAG}..${TAG_NAME} >> release_notes.md
-          else
-            echo "## Release $TAG_NAME" >> release_notes.md
-            echo "" >> release_notes.md
-            git log --max-count=20 --pretty=format:"- %s (%h)" >> release_notes.md
-          fi
-          
-          # Add footer
-          echo "" >> release_notes.md
-          echo "---" >> release_notes.md
-          echo "**Full Changelog**: https://github.com/JnyJny/busylight/compare/${PREVIOUS_TAG}...${TAG_NAME}" >> release_notes.md
+      - name: Download release notes
+        uses: actions/download-artifact@v4
+        with:
+          name: release-notes
 
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1
@@ -156,6 +146,5 @@ jobs:
           bodyFile: "release_notes.md"
           draft: false
           prerelease: false
-          generateReleaseNotes: true
+          generateReleaseNotes: false
           token: ${{ secrets.GITHUB_TOKEN }}
-          

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,71 @@
+# git-cliff configuration for busylight
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+header = """# CHANGELOG\n
+All notable changes to this project will be documented in this file.\n
+"""
+body = """
+{%- macro remote_url() -%}
+  https://github.com/JnyJny/busylight
+{%- endmacro -%}
+
+{% if version -%}
+## [{{ version | trim_start_matches(pat="v") }}]({{ self::remote_url() }}/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+## Unreleased
+{% endif -%}
+
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | split(pat="\n") | first | trim }}\
+  {% if commit.remote.pr_number %} \
+    ([#{{ commit.remote.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.remote.pr_number }}))\
+  {% endif %} \
+  ([{{ commit.id | truncate(length=7, end="") }}]({{ self::remote_url() }}/commit/{{ commit.id }}))\
+{%- endfor %}
+{% endfor %}
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+commit_parsers = [
+  # Skip merge commits, dependabot CI bumps, changelog updates, and version bumps
+  { message = "^Merge pull request", skip = true },
+  { message = "^Merge branch", skip = true },
+  { message = "^ci\\(deps\\)", skip = true },
+  { message = "^ci:", skip = true },
+  { message = "^docs\\(CHANGELOG\\)", skip = true },
+  { message = "^v\\d+\\.\\d+", skip = true },
+
+  # Standard conventional commits
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug Fixes" },
+  { message = "^bug", group = "Bug Fixes" },
+  { message = "^doc", group = "Documentation" },
+  { message = "^refactor", group = "Refactor" },
+  { message = "^perf", group = "Performance" },
+  { message = "^style", group = "Styling" },
+  { message = "^ci", group = "CI" },
+
+  # Legacy prefixes (older commits use inconsistent casing)
+  { message = "^BUG", group = "Bug Fixes" },
+  { message = "^Fix", group = "Bug Fixes" },
+  { message = "^Feature", group = "Features" },
+  { message = "^Cleanup", group = "Refactor" },
+  { message = "^YOLO", group = "Other" },
+
+  # Catch-all
+  { message = ".*", group = "Other" },
+]
+filter_commits = false
+tag_pattern = "v[0-9].*"
+skip_tags = ""
+ignore_tags = ""
+topo_order = false
+sort_commits = "newest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ packages = ["src/busylight"]
 dev = [
     "anyio>=4.9.0",
     "coverage>=7.8.0",
+    "git-cliff>=2.12.0",
     "httpx>=0.28.1",
     "poethepoet>=0.34.0",
     "pytest>=8.3.5",
@@ -111,6 +112,14 @@ publish_minor= ["_minor_bump", "_update_pyproject"]
 publish_major= ["_major_bump", "_update_pyproject"]
 
 publish = {ref = "publish_patch"}
+
+# release
+
+changelog.cmd = "git cliff"
+changelog.help = "[Release] Generate full changelog to stdout."
+
+release-notes.cmd = "git cliff --latest --strip header"
+release-notes.help = "[Release] Generate release notes for the latest tag."
 
 # clean
 [[tool.poe.tasks.clean]]

--- a/uv.lock
+++ b/uv.lock
@@ -101,6 +101,7 @@ webapi = [
 dev = [
     { name = "anyio" },
     { name = "coverage" },
+    { name = "git-cliff" },
     { name = "httpx" },
     { name = "poethepoet" },
     { name = "pytest" },
@@ -131,6 +132,7 @@ provides-extras = ["webapi", "web", "docs"]
 dev = [
     { name = "anyio", specifier = ">=4.9.0" },
     { name = "coverage", specifier = ">=7.8.0" },
+    { name = "git-cliff", specifier = ">=2.12.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "poethepoet", specifier = ">=0.34.0" },
     { name = "pytest", specifier = ">=8.3.5" },
@@ -353,6 +355,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "git-cliff"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/cf/dff8cd706d2e30e264cb3b9880235607188fb3ad596bfe6282147165bdcd/git_cliff-2.12.0.tar.gz", hash = "sha256:57b96b1f61167f85395353d6f47a89944b4882c03880312d53c09dacecb7ff86", size = 102106, upload-time = "2026-01-20T17:46:12.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/a5/dc5f800f6a6dc175faa0787653119754dbbe81a9db1274e041443690287b/git_cliff-2.12.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e9ee9aa29e9435211712fdab4b5ec9fb432c4bc9d244e39351b2be57aeba7999", size = 6879200, upload-time = "2026-01-20T17:45:55.964Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/b6/0e251bd49700e767c47d8d524a690ad713a3aed4318074278438042b8f25/git_cliff-2.12.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e18512138db5ef57302155b1163c0a2cf43c3d79071a5e083883b65bb990218c", size = 6456349, upload-time = "2026-01-20T17:45:58.202Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/63/4e8780f60ad28e8c26ae2b2b365daff9ffa84cb441a5d5bf62c42a75e75a/git_cliff-2.12.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d24c3e334fdf309c59802ea1a9cd3828e92c8c7cacdd619bcabdc638e00e2ade", size = 6916209, upload-time = "2026-01-20T17:45:59.931Z" },
+    { url = "https://files.pythonhosted.org/packages/71/83/0bfab93065e10bcbe97e6136ccf6c1e8552715ef61c11eb678c397ff5fb0/git_cliff-2.12.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1aa25b05a0315d0f58fc2ac21503538ca749fc3dd7476ee5d6bdf380d9f26ab", size = 7305605, upload-time = "2026-01-20T17:46:01.991Z" },
+    { url = "https://files.pythonhosted.org/packages/30/eb/78f624e387c1d9084ca7bcec3a8f28fda9fbbfbeb18c71465a727ee677b5/git_cliff-2.12.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:91eafd2f3ecf226b9a9c2a6c54d96df6042479927b48a97fcf46b728e8744bf1", size = 6927694, upload-time = "2026-01-20T17:46:03.798Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3f/735ddcb426c9f77498a039e9398162345c59f29c7990fbf22a530a15fb97/git_cliff-2.12.0-py3-none-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:26c9771a50a039252c67803f4c7f187f2ce9c5eea336b8cef890e94483af7a9d", size = 7118983, upload-time = "2026-01-20T17:46:05.535Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/97/68a5bd8063904fc43df7811e713483ccd831a877751283c6514dfb5b079e/git_cliff-2.12.0-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:168f48b82f81ab8e1625d42adb739471623e25bd0a7e25b8c70490bad9e90e2b", size = 7541855, upload-time = "2026-01-20T17:46:07.348Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/00/2ed0bf7d71340c20906c1317db50cd6c14bdf0c90fa68a62885c9daf40a9/git_cliff-2.12.0-py3-none-win32.whl", hash = "sha256:4bc609a748c1c3493fe3e00a48305d343255ddff80e564fbf8eb954aac387784", size = 6354818, upload-time = "2026-01-20T17:46:09.117Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/fd/679d54e4ed37fdbadb58080219af8f35b5f659dd25e47ab1951b6349d1d0/git_cliff-2.12.0-py3-none-win_amd64.whl", hash = "sha256:c992b5756298251ecdd4db8abe087e90d00327f9eaf0c2470a44dbff64377d07", size = 7303564, upload-time = "2026-01-20T17:46:11.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replaces BobAnkh/auto-generate-changelog with git-cliff for changelog generation, matching the pattern established in busylight-core.

**Changes:**
- Added `cliff.toml` with conventional commit parsing
- Added `git-cliff` as dev dependency
- Added `poe changelog` and `poe release-notes` tasks
- Updated release workflow: git-cliff generates both release notes and CHANGELOG.md
- Updated actions/checkout to v6, setup-uv to v7
- Removed BobAnkh/auto-generate-changelog dependency

Closes JnyJny/dispatch#669

Authored by Jny