### PR TITLE
ci: allow Python 3.14 test failures

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.12', '3.13', '3.14']
 
+    continue-on-error: ${{ matrix.python-version == '3.14' }}
+
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
PyO3 v0.24.1 (used by pydantic-core) does not yet support Python 3.14. Building from source on 3.14+Windows fails with:

```
error: the configured Python interpreter version (3.14) is newer than
PyO3's maximum supported version (3.13)
```

This adds `continue-on-error` for the 3.14 matrix jobs so they don't gate releases. The tests still run for visibility -- we'll remove this guard once pydantic-core ships 3.14 wheels (likely needs PyO3 0.25+).

*Authored by Jny*