### PR TITLE
docs: trim derivable/duplicated content from root CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,26 +29,6 @@ CLI and HTTP API built on busylight-core.
 - `src/busylight/controller.py` — Multi-device coordination
 - `src/busylight/api/` — FastAPI web server
 
-## Commands
-
-Run from package directories:
-
-```bash
-# busylight-core
-cd packages/busylight-core
-poe test              # unit tests
-poe doc-test          # validate code blocks in docs/
-poe ruff              # format + lint
-poe coverage          # coverage report
-poe docs-serve        # serve docs locally
-
-# busylight (CLI)
-cd packages/busylight
-poe test              # unit tests
-poe ruff              # format + lint (check + format)
-poe coverage          # coverage report
-```
-
 ## Architecture Rules
 
 **DO NOT consolidate vendor classes.** Each device gets its own class in
@@ -68,25 +48,6 @@ Automatic strategy selection:
 - **Asyncio context:** Uses `asyncio.Task`
 - **Non-asyncio context:** Uses `threading.Timer`
 - No user configuration needed
-
-## Adding Devices
-
-Goes in busylight-core:
-
-1. Create vendor package in `vendors/` if needed
-2. Implement `Light` subclass (`__bytes__`, `on`, `color` property)
-3. Define `supported_device_ids`
-4. Import in vendor `__init__.py` and main `__init__.py`
-5. Add tests in `tests/`
-
-## Doc Tests
-
-All Python code blocks in `packages/busylight-core/docs/` are tested
-via pytest-markdown-docs. Mock hardware in `docs/conftest.py`.
-
-- `continuation` marker for blocks depending on prior imports
-- `notest` marker to exclude blocks
-- **If you change a public API, update doc examples** — CI catches mismatches
 
 ## Code Style
 

--- a/packages/busylight-core/CLAUDE.md
+++ b/packages/busylight-core/CLAUDE.md
@@ -22,3 +22,13 @@ poe docs-serve    # serve docs locally
 - Three device patterns: simple, complex (Word/BitField), multi-LED
 - Doc tests run on all Python blocks in `docs/` — update examples when changing APIs
 - Mock hardware in `docs/conftest.py`
+- `continuation` marker for doc-test blocks depending on prior imports
+- `notest` marker to exclude a block from doc-testing
+
+### Adding Devices
+
+1. Create vendor package in `vendors/` if needed
+2. Implement `Light` subclass (`__bytes__`, `on`, `color` property)
+3. Define `supported_device_ids`
+4. Import in vendor `__init__.py` and main `__init__.py`
+5. Add tests in `tests/`


### PR DESCRIPTION
## What changed

- Removed the `## Commands` section from the root `CLAUDE.md` (11 lines). It duplicated the `poe` task definitions already in each package's `pyproject.toml` (`[tool.poe.tasks]`) and was repeated verbatim in `packages/busylight/CLAUDE.md` and `packages/busylight-core/CLAUDE.md`.
- Moved `## Adding Devices` and the doc-test marker details (`continuation`/`notest`) out of the root `CLAUDE.md` and into `packages/busylight-core/CLAUDE.md`, since they're specific to that package and only matter when working there.

## Why

Root `CLAUDE.md` is loaded into context in every session regardless of which package is being worked on. This content was either derivable from `pyproject.toml`/nested files or only relevant to `busylight-core`, so moving/cutting it trims what's always-loaded without losing any information — the nested `packages/busylight-core/CLAUDE.md` picks it up and loads only when working under that package.

## Notes for reviewer

- Purely a documentation reorganization — no code changes.
- Safety-critical rules (e.g. "DO NOT consolidate vendor classes") were left in the root file since it's a "never do X" prohibition that should stay always-loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)