### PR TITLE
misc: harmonize ruff config between packages, track lint backlog

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,40 @@
+# TODO
+
+## `busylight` lint backlog (ruff)
+
+`packages/busylight` was recently switched from a narrow ruff `select`
+(`E`, `F`, `I`, `W`) to the same `["I", "ALL"]` baseline `busylight-core`
+already used, via the new shared [ruff.toml](ruff.toml). That surfaced
+523 pre-existing findings that were never being checked before. They're
+selected (visible in `ruff check`, will show red in CI) but intentionally
+not fixed yet — tracked here instead of silently ignored.
+
+Reproduce: `cd packages/busylight && ruff check src tests`
+
+By rule, most to least:
+
+| Rule | Count | What |
+|---|---|---|
+| `ANN201` | 115 | Missing return type annotation, public function — **~105 of these are `test_*` functions missing `-> None`**; worth reconsidering as a `tests/*` per-file-ignore rather than fixing by hand, since annotating every test's trivial `None` return is low-value |
+| `FAST002` | 62 | FastAPI dependency not using `Annotated[]` style |
+| `PLC0415` | 43 | `import` not at module top-level |
+| `TID252` | 33 | Relative imports (should be absolute) |
+| `FAST001` | 30 | FastAPI route with redundant `response_model` |
+| `D102` | 27 | Missing docstring, public method |
+| `D413` | 20 | Missing blank line after docstring's last section |
+| `D103` | 17 | Missing docstring, public function |
+| `B904` | 16 | `raise` inside `except` without `from` |
+| `D101` | 12 | Missing docstring, public class |
+| `PT006` | 11 | Wrong type for `pytest.mark.parametrize`'s first arg |
+| `PLR0917` | 19 | Too many positional arguments |
+| `D107` | 10 | Missing docstring, `__init__` |
+| `ARG001` | 9 | Unused function argument |
+| `D202` | 8 | Blank line after function docstring |
+| `SIM117` | 6 | Nested `with` should be a single statement |
+| `D419` | 5 | Empty docstring |
+| `B008` | 5 | `typer.Option(...)` call in argument default (framework pattern — likely another `extend-immutable-calls` candidate, not a real bug) |
+| everything else | ~60 | Singles/low counts — `TRY003`, `RUF013`, `RSE102`, `D205`, `TC005`, `EM102`, `D404`, `ANN202`, `SIM105`, `S104`, `RUF006`, `PLW0603`, and more. Full list via the reproduce command above. |
+
+`busylight-core` has one pre-existing, unrelated finding of its own:
+`PLR0917` (too many positional arguments) in
+`src/busylight_core/vendors/kuando/implementation/commands.py`.

--- a/packages/busylight-core/pyproject.toml
+++ b/packages/busylight-core/pyproject.toml
@@ -168,57 +168,8 @@ known_first_party = ["busylight_core"]
 package_module_name_map = {pyserial = "serial", hidapi = "hid"}
 
 [tool.ruff]
+extend = "../../ruff.toml"
 fix = true
-lint.select = [
-  # isort
-  "I",
-  # ok isort is in all.
-  "ALL"
-]
-lint.ignore = [
-  # ARG002 Unused method argument
-  "ARG002",
-  # Missing docstring in magic method
-  "D105",
-  # missing-trailing-comma (COM812)
-  "COM812",
-  # incorrect-blank-line-before-class (D203)
-  "D203",
-  # blank-line-before-class (D211)
-  "D211",
-  # multi-line-summary-first-line (D212)
-  "D212",
-  # multi-line-summary-second-line (D213)
-  "D213",
-  # boolean-type-hint-positional-argument (FBT001)
-  "FBT001",
-  # boolean-positional-value-in-call (FBT003)
-  "FBT003",
-  # missing-trailing-period (D400)
-  "D400",
-  # first-line-ends-in-period (D415)
-  "D415",
-  # blank-except (BLE001)
-  "BLE001",
-  # invalid-class-name (N801)
-  "N801",
-  # boolean-default-value-positional-argument (FBT002)
-  "FBT002",
-  # magic-value-comparison (PLR2004)
-  "PLR2004",
-  # too-many-arguments (PLR0913)
-  "PLR0913",
-  # non-unique-enums (PIE796)
-  "PIE796",
-  # missing-type-function-argument (ANN001)
-  "ANN001",
-  # missing-return-type-special-method (ANN204)
-  "ANN204",
-  # str-enum-inheritance (UP042) -- StrEnum requires Python 3.11+
-  "UP042",
-  # replace-bin-call (FURB116) -- current form is clearer with zfill
-  "FURB116",
- ]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = [

--- a/packages/busylight/pyproject.toml
+++ b/packages/busylight/pyproject.toml
@@ -67,11 +67,11 @@ package_module_name_map = {pyserial = "serial", hidapi = "hid", "busylight-core"
 per_rule_ignores = {DEP002 = ["hidapi", "pyserial", "mkdocs", "mkdocs-material", "mkdocs-git-revision-date-localized-plugin"], DEP003 = ["pydantic"]}
 
 [tool.ruff]
+extend = "../../ruff.toml"
 fix = false
 line-length = 90
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "W"]
 ignore = [
   # comparison-to-singleton (E711, E712) -- legacy code style
   "E711",
@@ -84,11 +84,27 @@ ignore = [
   "I001",
   # unused-variable (F841) -- some are intentional side-effect calls
   "F841",
+  # print-found (T201) -- CLI package, stdout output is the point
+  "T201",
 ]
+
+[tool.ruff.lint.flake8-bugbear]
+# FastAPI's DI pattern calls Depends()/Query()/Path() in argument defaults
+# by design -- this isn't the mutable-default-arg bug B008 looks for.
+extend-immutable-calls = ["fastapi.Depends", "fastapi.Query", "fastapi.Path"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = [
+  # implicit-namespace-package (INP001) -- intentionally no __init__.py
+  "INP001",
+  # use-of-assert (S101) -- assert is the point in test code
+  "S101",
   "F841",
+]
+"src/busylight/busyserve.py" = [
+  # hardcoded-bind-all-interfaces (S104) -- deliberate, documented,
+  # user-overridable via --host
+  "S104",
 ]
 
 

--- a/packages/busylight/src/busylight/api/busylight_api.py
+++ b/packages/busylight/src/busylight/api/busylight_api.py
@@ -3,7 +3,8 @@
 from json import loads as json_loads
 from os import environ
 from secrets import compare_digest
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 
 from busylight_core import Light, LightUnavailableError, NoLightsFoundError
 from fastapi import Depends, FastAPI, HTTPException, Path, Request, Response, status

--- a/packages/busylight/src/busylight/api/config.py
+++ b/packages/busylight/src/busylight/api/config.py
@@ -101,7 +101,7 @@ def get_api_settings_from_env() -> APISettings:
         raise
 
 
-@lru_cache()
+@lru_cache
 def get_settings() -> APISettings:
     """Cached API settings instance."""
     return get_api_settings_from_env()

--- a/packages/busylight/src/busylight/api/logging_config.py
+++ b/packages/busylight/src/busylight/api/logging_config.py
@@ -7,7 +7,7 @@ with uvicorn.
 
 import logging
 import sys
-from typing import Any, Dict
+from typing import Any
 
 from loguru import logger
 
@@ -68,7 +68,7 @@ def setup_logging(debug: bool = False) -> None:
     logger.info("Logging configuration complete")
 
 
-def get_uvicorn_log_config(debug: bool = False) -> Dict[str, Any]:
+def get_uvicorn_log_config(debug: bool = False) -> dict[str, Any]:
     """Get uvicorn logging configuration that integrates with loguru.
 
     Args:

--- a/packages/busylight/src/busylight/api/main.py
+++ b/packages/busylight/src/busylight/api/main.py
@@ -1,7 +1,7 @@
 """FastAPI Application Factory."""
 
 from contextlib import asynccontextmanager
-from typing import AsyncGenerator
+from collections.abc import AsyncGenerator
 
 from busylight_core import LightUnavailableError, NoLightsFoundError
 from fastapi import FastAPI

--- a/packages/busylight/src/busylight/api/middleware.py
+++ b/packages/busylight/src/busylight/api/middleware.py
@@ -7,7 +7,7 @@ the current hardware state when devices are connected or disconnected
 during runtime.
 """
 
-from typing import Callable
+from collections.abc import Callable
 
 from fastapi import Request, Response
 from loguru import logger

--- a/packages/busylight/src/busylight/controller.py
+++ b/packages/busylight/src/busylight/controller.py
@@ -25,7 +25,8 @@ from __future__ import annotations
 import asyncio
 import re
 from dataclasses import dataclass, field
-from typing import Iterator, Pattern
+from re import Pattern
+from collections.abc import Iterator
 
 from busylight_core import Light, LightUnavailableError
 from loguru import logger

--- a/packages/busylight/src/busylight/subcommands/blink.py
+++ b/packages/busylight/src/busylight/subcommands/blink.py
@@ -18,8 +18,6 @@ Example:
         busylight blink "#00ff00" --count 0  # Infinite blinking
 """
 
-from typing import Optional
-
 import typer
 from busylight_core import NoLightsFoundError
 from loguru import logger
@@ -35,7 +33,7 @@ blink_cli = typer.Typer()
 @blink_cli.command(name="blink")
 def blink_lights(
     ctx: typer.Context,
-    color: Optional[str] = typer.Argument(
+    color: str | None = typer.Argument(
         "red",
         callback=string_to_scaled_color,
         show_default=True,

--- a/packages/busylight/src/busylight/subcommands/fli.py
+++ b/packages/busylight/src/busylight/subcommands/fli.py
@@ -1,7 +1,5 @@
 """Fli Command Line Interface"""
 
-from typing import Optional
-
 import typer
 from busylight_core import NoLightsFoundError
 from loguru import logger
@@ -18,13 +16,13 @@ fli_cli = typer.Typer()
 @fli_cli.command(name="fli")
 def flash_lights_impressively(
     ctx: typer.Context,
-    on_color: Optional[str] = typer.Argument(
+    on_color: str | None = typer.Argument(
         "red",
         callback=string_to_scaled_color,
         help="Primary color of the fli effect.",
         show_default=True,
     ),
-    off_color: Optional[str] = typer.Argument(
+    off_color: str | None = typer.Argument(
         "blue",
         callback=string_to_scaled_color,
         help="Secondary color of the fli effect.",

--- a/packages/busylight/src/busylight/subcommands/on.py
+++ b/packages/busylight/src/busylight/subcommands/on.py
@@ -19,8 +19,6 @@ Example:
 
 """
 
-from typing import Optional
-
 import typer
 from busylight_core import NoLightsFoundError
 from loguru import logger
@@ -35,7 +33,7 @@ on_cli = typer.Typer()
 @on_cli.command(name="on")
 def activate_lights(
     ctx: typer.Context,
-    color: Optional[str] = typer.Argument(
+    color: str | None = typer.Argument(
         "green",
         callback=string_to_scaled_color,
         show_default=True,

--- a/packages/busylight/src/busylight/subcommands/on_new.py
+++ b/packages/busylight/src/busylight/subcommands/on_new.py
@@ -1,7 +1,5 @@
 """On Command with new LightController."""
 
-from typing import Optional
-
 import typer
 from busylight_core import NoLightsFoundError
 from loguru import logger
@@ -12,7 +10,7 @@ on_cli = typer.Typer()
 @on_cli.command(name="on")
 def activate_lights(
     ctx: typer.Context,
-    color: Optional[str] = typer.Argument(
+    color: str | None = typer.Argument(
         "green",
         show_default=True,
     ),

--- a/packages/busylight/src/busylight/subcommands/pulse.py
+++ b/packages/busylight/src/busylight/subcommands/pulse.py
@@ -1,7 +1,5 @@
 """Pulse Command Line Interface"""
 
-from typing import Optional
-
 import typer
 from busylight_core import NoLightsFoundError
 from loguru import logger
@@ -18,7 +16,7 @@ pulse_cli = typer.Typer()
 @pulse_cli.command(name="pulse")
 def pulse_lights(
     ctx: typer.Context,
-    color: Optional[str] = typer.Argument(
+    color: str | None = typer.Argument(
         "green",
         callback=string_to_scaled_color,
         help="Color of the pulse effect.",

--- a/packages/busylight/tests/test_color_functions.py
+++ b/packages/busylight/tests/test_color_functions.py
@@ -1,7 +1,5 @@
 """Test Color Handling"""
 
-from typing import Tuple
-
 import pytest
 from busylight.color import (
     ColorLookupError,
@@ -26,7 +24,7 @@ from busylight.color import (
         ("0X000", (0, 0, 0)),
     ],
 )
-def test_parse_color_string(value: str, expected: Tuple[int, int, int]) -> None:
+def test_parse_color_string(value: str, expected: tuple[int, int, int]) -> None:
     result = parse_color_string(value)
     assert result == expected
 
@@ -62,7 +60,7 @@ def test_parse_color_string_invalid(value: str) -> None:
         ((0, 0, 255), "blue"),
     ],
 )
-def test_colortuple_to_name(value: Tuple[int, int, int], expected: str) -> None:
+def test_colortuple_to_name(value: tuple[int, int, int], expected: str) -> None:
     result = colortuple_to_name(value)
     assert result == expected
 
@@ -70,7 +68,7 @@ def test_colortuple_to_name(value: Tuple[int, int, int], expected: str) -> None:
 @pytest.mark.parametrize(
     "color,expected", [((0, 0, 1), "#000001"), ((255, 254, 253), "#fffefd")]
 )
-def test_colortuple_to_name_unknown_color(color: Tuple[int, int, int], expected) -> None:
+def test_colortuple_to_name_unknown_color(color: tuple[int, int, int], expected) -> None:
     result = colortuple_to_name(color)
     assert result == expected
 
@@ -93,7 +91,7 @@ def test_colortuple_to_name_unknown_color(color: Tuple[int, int, int], expected)
     ],
 )
 def test_scale_color(
-    source: Tuple[int, int, int], scale: float, expected: Tuple[int, int, int]
+    source: tuple[int, int, int], scale: float, expected: tuple[int, int, int]
 ) -> None:
     result = scale_color(source, scale)
     assert result == expected

--- a/packages/busylight/tests/test_pydantic_models.py
+++ b/packages/busylight/tests/test_pydantic_models.py
@@ -1,6 +1,6 @@
 """ """
 
-from typing import Any, Dict, Tuple
+from typing import Any
 
 import pytest
 from busylight.api.models import EndPoint, LightDescription, LightOperation
@@ -46,10 +46,10 @@ def test_model_endpoint(path, expected_exception) -> None:
 def test_model_lightdescription(
     light_id: int,
     name: str,
-    info: Dict[str, Any],
+    info: dict[str, Any],
     is_on: bool,
     color: str,
-    rgb: Tuple[int, int, int],
+    rgb: tuple[int, int, int],
 ) -> None:
     light_description = LightDescription(
         light_id=light_id, name=name, info=info, is_on=is_on, color=color, rgb=rgb
@@ -75,7 +75,7 @@ def test_model_lightoperation(
     light_id: int,
     action: str,
     color: str,
-    rgb: Tuple[int, int, int],
+    rgb: tuple[int, int, int],
     speed: str,
     name: str,
     dim: bool,

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,57 @@
+# Shared ruff baseline for both packages/*. Each package's pyproject.toml
+# extends this file and layers on package-specific per-file-ignores and
+# framework-specific settings. See CLAUDE.md for the rationale.
+
+[lint]
+select = ["I", "ALL"]
+ignore = [
+  # unused-method-argument (ARG002) -- common in Protocol/ABC implementations
+  "ARG002",
+  # missing-docstring-in-magic-method (D105)
+  "D105",
+  # missing-trailing-comma (COM812) -- handled by formatter
+  "COM812",
+  # incorrect-blank-line-before-class (D203)
+  "D203",
+  # blank-line-before-class (D211)
+  "D211",
+  # multi-line-summary-first-line (D212)
+  "D212",
+  # multi-line-summary-second-line (D213)
+  "D213",
+  # boolean-type-hint-positional-argument (FBT001)
+  "FBT001",
+  # boolean-positional-value-in-call (FBT003)
+  "FBT003",
+  # boolean-default-value-positional-argument (FBT002)
+  "FBT002",
+  # missing-trailing-period (D400)
+  "D400",
+  # first-line-ends-in-period (D415)
+  "D415",
+  # blank-except (BLE001)
+  "BLE001",
+  # invalid-class-name (N801)
+  "N801",
+  # magic-value-comparison (PLR2004)
+  "PLR2004",
+  # too-many-arguments (PLR0913)
+  "PLR0913",
+  # non-unique-enums (PIE796)
+  "PIE796",
+  # missing-type-function-argument (ANN001)
+  "ANN001",
+  # missing-return-type-special-method (ANN204)
+  "ANN204",
+  # str-enum-inheritance (UP042) -- StrEnum requires Python 3.11+
+  "UP042",
+  # replace-bin-call (FURB116) -- current form is clearer with zfill
+  "FURB116",
+  # missing-copyright-notice (CPY001) -- not used in this repo
+  "CPY001",
+]
+
+# Note: per-file-ignores do NOT merge across `extend` -- a package that
+# defines "tests/*" here would silently replace, not add to, this list.
+# Each package's own pyproject.toml restates the full per-file-ignore set
+# it needs, including these two.


### PR DESCRIPTION
## What changed

`busylight-core` and `busylight` had drifted to very different ruff enforcement bars — an artifact of the two being hand-written separately before this became a uv workspace, not a deliberate choice (confirmed with @JnyJny in chat).

- Added [ruff.toml](ruff.toml) at the workspace root as a shared baseline. Both packages now `extend = "../../ruff.toml"` instead of duplicating (and drifting from) each other's `select`/`ignore` lists.
- `busylight` now extends the same `["I", "ALL"]` baseline `busylight-core` already used, instead of its old narrow `["E", "F", "I", "W"]`. Framework-specific additions layered locally:
  - `T201` (print) ignored — it's a CLI package, stdout output is the point.
  - `flake8-bugbear.extend-immutable-calls` covers FastAPI's `Depends`/`Query`/`Path` — that's the correct DI pattern, not the mutable-default-arg bug `B008` looks for.
  - `S104` (bind-all-interfaces) scoped to just `busyserve.py`, where `--host 0.0.0.0` is a deliberate, documented, user-overridable default.
- Autofixed the mechanical findings this surfaced: old-style typing (`Dict`/`Tuple`/`Optional` → `dict`/`tuple`/`X | None`) plus the resulting unused-import and formatting fallout.
- Everything else this surfaced — **523 findings**, tracked in [TODO.md](TODO.md) — is intentionally left selected-but-unfixed rather than fixed inline or silently re-ignored.

## Why

Config drift between the two packages meant `busylight`'s effective code-quality bar (missing docstrings, missing type annotations, relative imports, etc.) was invisible to CI. This makes the bar consistent and explicit again, without pretending the backlog it reveals doesn't exist.

## Notes for reviewer

- **This turns `busylight`'s Lint CI check red.** That's not a bug — the config now enforces rules the code hasn't caught up to yet. `busylight-core`'s Lint check has also been red already, from one pre-existing, unrelated `PLR0917` finding (not introduced by this PR).
- Verified before pushing: `busylight` tests 181/181 passing, `busylight-core` tests 850/850 passing, `ruff format --check` clean on both packages.
- Per-file-ignores don't merge across ruff's `extend` mechanism (verified empirically, noted in `ruff.toml`) — each package keeps its own complete per-file-ignore lists rather than relying on inheritance for those.
- `TODO.md` groups the 523-finding backlog by rule so it's actionable as follow-up work, including one specific suggestion: ~105 of the 115 `ANN201` hits are `test_*` functions missing `-> None`, which may be a better fit for a `tests/*` per-file-ignore than hand-annotating each one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)